### PR TITLE
Report both declarations and ids for bindings

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -160,14 +160,15 @@ function declarationsOfScope(scope, includeOuter) {
 function declarationsWithIdsOfScope(scope) {
   // returns a list of pairs [(DeclarationNode,IdentifierNode)]
   const bareIds = helpers.declIds(scope.params)
-    .concat(scope.catches)
-    .concat(scope.importDecls);
+    .concat(scope.catches);
   const declNodes = (scope.node.id && scope.node.id.name ? [scope.node] : [])
     .concat(scope.funcDecls)
     .concat(scope.classDecls);
   return bareIds.map(ea => [ea, ea])
     .concat(declNodes.map(ea => [ea, ea.id]))
-    .concat(helpers.varDecls(scope));
+    .concat(helpers.varDecls(scope))
+    .concat(scope.importDecls.map(im => {
+      return [statementOf(scope.node, im), im]}));
 }
 
 function _declaredVarNames(scope, useComments) {
@@ -195,20 +196,24 @@ function topLevelFuncDecls(parsed) {
 function resolveReference(ref, scopePath) {
   if (scopePath.length == 0) return [null, null];
   const [scope, ...outer] = scopePath;
-  const decls = declarationsWithIdsOfScope(scope, true);
+  const decls = scope.decls || declarationsWithIdsOfScope(scope);
+  scope.decls = decls;
   const decl = decls.find(([_, id]) => id.name == ref);
   return decl || resolveReference(ref, outer);
 }
 
-function resolveReferences(scope, outerScopes = []) {
+function resolveReferences(scope) {
+  function rec(scope, outerScopes) {
+    const path = [scope].concat(outerScopes);
+    scope.refs.forEach(ref => {
+      const [decl, id] = resolveReference(ref.name, path);
+      if (decl) ref.decl = obj.deepCopy(decl);
+      if (id) ref.declId = obj.deepCopy(id);
+    });
+    scope.subScopes.forEach(s => rec(s, path));
+  }
   if (scope.referencesResolved) return scope;
-  const path = [scope].concat(outerScopes);
-  scope.refs.forEach(ref => {
-    const [decl, id] = resolveReference(ref.name, path);
-    if (decl) ref.decl = obj.deepCopy(decl);
-    if (id) ref.declId = obj.deepCopy(id);
-  });
-  scope.subScopes.forEach(s => resolveReferences(s, path));
+  rec(scope, []);
   scope.referencesResolved = true;
   return scope;
 }
@@ -307,24 +312,40 @@ function nodesAt(pos, ast) {
   return acorn.walk.findNodesIncluding(ast, pos);
 }
 
+const _stmtTypes = [
+  "EmptyStatement",
+  "BlockStatement",
+  "ExpressionStatement",
+  "IfStatement",
+  "BreakStatement",
+  "ContinueStatement",
+  "WithStatement",
+  "ReturnStatement",
+  "ThrowStatement",
+  "TryStatement",
+  "WhileStatement",
+  "DoWhileStatement",
+  "ForStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "DebuggerStatement",
+  "FunctionDeclaration",
+  "VariableDeclaration",
+  "ClassDeclaration",
+  "ImportDeclaration",
+  "ImportDeclaration",
+  "ExportNamedDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportAllDeclaration"];
+
 function statementOf(parsed, node, options) {
   // Find the statement that a target node is in. Example:
   // let source be "var x = 1; x + 1;" and we are looking for the
   // Identifier "x" in "x+1;". The second statement is what will be found.
-  var nodes = nodesAt(node.start, parsed);
-  if (nodes.indexOf(node) === -1) return undefined;
-  var found = nodes.reverse().find((node, i) => {
-    if (!nodes[i+1]) return false;
-    var t = nodes[i+1].type;
-    return ["BlockStatement",
-            "Program",
-            "FunctionDeclaration",
-            "FunctionExpress",
-            "ArrowFunctionExpress",
-            "SwitchCase", "SwitchStatement"].indexOf(t) > -1 ? true : false;
-  });
+  const nodes = nodesAt(node.start, parsed);
+  const found = nodes.reverse().find(node => _stmtTypes.includes(node.type));
   if (options && options.asPath) {
-    var v = new BaseVisitor(), foundPath;
+    let v = new BaseVisitor(), foundPath;
     v.accept = fun.wrap(v.accept, (proceed, node, state, path) => {
       if (node === found) { foundPath = path; throw new Error("stop search"); };
       return proceed(node, state, path);
@@ -439,8 +460,8 @@ function exports(scope) {
           fromModule:      from || null,
           node:            node,
           type:            "id",
-          decl:            exportSpec.local.decl,
-          declId:          exportSpec.local.declId
+          decl:            from ? node : exportSpec.local && exportSpec.local.decl,
+          declId:          from ? exportSpec.exported : exportSpec.local && exportSpec.local.declId
         }
       }))
     }

--- a/tests/query-test.js
+++ b/tests/query-test.js
@@ -260,23 +260,23 @@ describe('query', function() {
 
     itFindsTheStatment(
       'if (true) var a = 1;',
-      ast => ast.body[0].consequent.declarations[0],
-      ast => ast.body[0]);
+      ast => ast.body[0].consequent.declarations[0].id,
+      ast => ast.body[0].consequent);
 
     itFindsTheStatment(
-      'if (true) var a = 1; else var a = 2;',
-      ast => ast.body[0].alternate.declarations[0],
+      'if (true) var a = 2;',
+      ast => ast.body[0].test,
       ast => ast.body[0]);
 
     itFindsTheStatment(
       'export default class Foo {}',
       ast => ast.body[0].declaration.id,
-      ast => ast.body[0]);
+      ast => ast.body[0].declaration);
 
     itFindsTheStatment(
-      'a;', // testing scenario where node is not found
-      ast => ({type: 'EmptyStatement'}),
-      ast => undefined);
+      'a;',
+      ast => ast.body[0].expression,
+      ast => ast.body[0]);
 
     it("finds path to statement", () => {
       var parsed = parse('var x = 3; function foo() { var y = 3; return y + 2 }; x + foo();'),

--- a/tests/reference-test.js
+++ b/tests/reference-test.js
@@ -58,8 +58,8 @@ describe('references', () => {
     it("can be referenced", () => {
       const refs = getRefs(22, "import {x} from 'm'; x + 1");
       expect(refs).to.containSubset({
-        decl: {start: 8, end: 9},
-        declId: {start: 8, end: 9}
+        decl: {start: 0, end: 20, type: "ImportDeclaration"},
+        declId: {start: 8, end: 9, type: "Identifier", name: "x"}
       });
     });
   });


### PR DESCRIPTION
Declaration is necessary for "Jump to Definition". Identifiers are important for refactoring, e.g. renaming. This change makes sure that both get reported at the same time, so clients can choose the appropriate information.
