### PR TITLE
Ensure keys of shorthand properties are not renamed while capturing

### DIFF
--- a/lib/capturing.js
+++ b/lib/capturing.js
@@ -1,5 +1,5 @@
 import { obj, chain, arr, fun, Path } from "lively.lang";
-import { member, varDecl, assign, id, literal, exprStmt, funcCall } from "./nodes.js";
+import { member, prop, varDecl, assign, id, literal, exprStmt, funcCall } from "./nodes.js";
 import { parse } from "./parser.js";
 import { topLevelDeclsAndRefs } from "./query.js";
 import { transformSingleExpression, wrapInStartEndCall } from "./transform.js";
@@ -259,8 +259,13 @@ function replaceWithMany(parsed, replacer) { return ReplaceManyVisitor.run(parse
 function replaceRefs(parsed, options) {
   var topLevel = topLevelDeclsAndRefs(parsed),
       refsToReplace = topLevel.refs.filter(ref => shouldRefBeCaptured(ref, topLevel, options));
+  
+  const replaced = replace(parsed, (node, path) =>
+    node.type === "Property" &&
+    refsToReplace.indexOf(node.key) > -1 &&
+    node.shorthand ? prop(id(node.key.name), node.value) : node);
 
-  return replace(parsed, (node, path) =>
+  return replace(replaced, (node, path) =>
     refsToReplace.indexOf(node) > -1 ? member(options.captureObj, node) : node);
 }
 

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -3,6 +3,7 @@ export {
   id,
   literal,
   objectLiteral,
+  prop,
   exprStmt,
   returnStmt,
   empty,
@@ -150,18 +151,22 @@ function tryStmt(exName, handlerBody, finalizerBody, ...body) {
   }
 }
 
+function prop(key, value) {
+  return {
+    type: "Property",
+    key: key,
+    computed: key.type !== "Identifier",
+    shorthand: false,
+    value: value
+  };
+}
+
 function objectLiteral(keysAndValues) {
   var props = [];
   for (var i = 0; i < keysAndValues.length; i += 2) {
     var key = keysAndValues[i];
     if (typeof key === "string") key = id(key);
-    props.push({
-      type: "Property",
-      key: key,
-      computed: key.type !== "Identifier",
-      shorthand: false,
-      value: keysAndValues[i+1]
-    })
+    props.push(prop(key, keysAndValues[i+1]));
   }
   return {
     properties: props,

--- a/tests/capturing-test.js
+++ b/tests/capturing-test.js
@@ -103,6 +103,13 @@ describe("ast.capturing", function() {
                  "_rec.x = 23;\n_rec.y = _rec.x + 1;");
     });
 
+    describe("enhanced object literals", () => {
+
+      testVarTfm("captures shorthand properties",
+                 "var x = 23, y = {x};",
+                 "_rec.x = 23;\n_rec.y = { x: _rec.x };");
+    });
+
     describe("class", () => {
 
       describe("with class-to-func transform", () => {


### PR DESCRIPTION
Currently, shorthand properties are incorrectly replaced as seen below:

``` js
var x = 23,
    y = {x};

// =>

var _rec.x = 23;
    _rec.y = { _rec.x };
```

The resulting AST is not correct anymore because you cannot use a property expression as key. This PR ensures that the key and value of short-hand properties is split up and only the value gets replaced by the capturing expression.
